### PR TITLE
Enable running only selected subfolders

### DIFF
--- a/AntispamTester.py
+++ b/AntispamTester.py
@@ -7,6 +7,8 @@ SpamFolderName = 'spam'
 HamFolderName = 'ham'
 
 Dirs = os.listdir(os.curdir + '/Tests')
+if len(sys.argv) > 1:
+    Dirs = sys.argv[1:]
 
 SpamCount = 0
 HamCount = 0

--- a/README.md
+++ b/README.md
@@ -14,4 +14,7 @@ Put AntispamTester.py to the same folder as antispam. E-mails, which are to be t
     - ./[subfolder2_name]
     ...
 
+
+For running only selected subfolders, specify their names as AntispamTester.py arguments.
+
 Large e-mail database: https://labs-repos.iit.demokritos.gr/skel/i-config/downloads/enron-spam/preprocessed/


### PR DESCRIPTION
This commit enables picking subfolders to be run.

Example use:
    (if we have Tests/subfolder1 to Tests/subfolder6)
    `./AntispamTester.py subfolder1 subfolder6`
    will run only tests from subfolder1 and subfolder6

Signed-off-by: Matej Marusak <mmarusak@redhat.com>